### PR TITLE
Fix typo ignoring hints reader in list

### DIFF
--- a/binlog/connection.py
+++ b/binlog/connection.py
@@ -456,7 +456,7 @@ class Connection:
                     except:
                         continue
                     else:
-                        if name != "Hints":
+                        if name != "hints":
                             readers.append(name)
         return readers
 

--- a/tests/unit/test_50_list_readers.py
+++ b/tests/unit/test_50_list_readers.py
@@ -17,4 +17,7 @@ def test_list_readers(readers):
             for name in readers:
                 db.register_reader(name)
 
+            # 'hints' should be ignored by list_readers()
+            db.register_reader('hints')
+
             assert set(db.list_readers()) == readers


### PR DESCRIPTION
Perhaps this (or something along this way) should help fix #10?  Adjusted an existing test to make sure the 'hints' reader is not reported by list_readers() method.  Thanks a lot!